### PR TITLE
Update the language/localization JSON schemas

### DIFF
--- a/assets/base/lang/game.schema.json
+++ b/assets/base/lang/game.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/game.schema.json",
-  "title": "Cosmic Reach language",
-  "description": "FinalForEach's Cosmic Reach game localization language schema",
+  "title": "Cosmic Reach language (game)",
+  "description": "FinalForEach's Cosmic Reach game localization language schema for game.json",
   "type": "object",
   "additionalProperties": false,
   "__HOW_TO_ADD_PROPERTY__": "First, copy-paste a previous property ({type: 'string'} etc.), then change its key. Then update the minProperties field below to match the total count of the defined properties. (e.g. add 1 if you add 1 text etc.)",
@@ -11,7 +11,8 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required."
+      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required.",
+      "const": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/game.schema.json"
     },
     "metadata": {
       "type": "object",

--- a/assets/base/lang/odd-tips.schema.json
+++ b/assets/base/lang/odd-tips.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/odd-tips.schema.json",
-  "title": "Cosmic Reach language",
-  "description": "FinalForEach's Cosmic Reach game localization language schema",
+  "title": "Cosmic Reach language (odd tips)",
+  "description": "FinalForEach's Cosmic Reach game localization language schema for odd-tips.json",
   "type": "object",
   "additionalProperties": false,
   "__HOW_TO_ADD_PROPERTY__": "First, copy-paste a previous property ({type: 'string'} etc.), then change its key. Then update the minProperties field below to match the total count of the defined properties. (e.g. add 1 if you add 1 text etc.)",
@@ -11,7 +11,8 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required."
+      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required.",
+      "const": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/odd-tips.schema.json"
     },
     "OddTip1": {
       "type": "string"

--- a/assets/base/lang/tip.schema.json
+++ b/assets/base/lang/tip.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/tip.schema.json",
-  "title": "Cosmic Reach language",
-  "description": "FinalForEach's Cosmic Reach game localization language schema",
+  "title": "Cosmic Reach language (tip)",
+  "description": "FinalForEach's Cosmic Reach game localization language schema for tip.json",
   "type": "object",
   "additionalProperties": false,
   "__HOW_TO_ADD_PROPERTY__": "First, copy-paste a previous property ({type: 'string'} etc.), then change its key. Then update the minProperties field below to match the total count of the defined properties. (e.g. add 1 if you add 1 text etc.)",
@@ -11,7 +11,8 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required."
+      "description": "Special property defining this schema as the schema of the language, e.g. should be same to the root $id property. Since this field does count to the total root minProperties property, it is required.",
+      "const": "https://raw.githubusercontent.com/FinalForEach/Cosmic-Reach-Localization/master/assets/base/lang/tip.schema.json"
     },
     "Tip1": {
       "type": "string"


### PR DESCRIPTION
I've updated the language/localization JSON schemas to make them have different titles and require the $schema string in them to match the GitHub URL of that schema.

That should hopefully make it more clear which schema is which.