### PR TITLE
0.4.10 updates

### DIFF
--- a/assets/base/lang/sv_se/base_blocks.json
+++ b/assets/base/lang/sv_se/base_blocks.json
@@ -75,5 +75,7 @@
     "base:clay": "Lera",
     "base:stone_shale": "Skiffersten",
     "base:piston": "Kolv",
-    "base:piston::suction": "Dragkolv"
+    "base:piston::suction": "Dragkolv",
+    "base:ore_ruby": "Rubinmalm",
+    "base:ruby_block": "Rubinblock"
 }

--- a/assets/base/lang/sv_se/base_items.json
+++ b/assets/base/lang/sv_se/base_items.json
@@ -20,5 +20,6 @@
     "base:rubber_ball": "Gummi",
     "base:laser_gun": "Lasergevär",
     "base:jetpack": "Jetpack",
-    "base:flamethrower": "Eldspruta"
+    "base:flamethrower": "Eldspruta",
+    "base:ruby": "Rubin"
 }


### PR DESCRIPTION
Added the rubies. Considered calling the ruby ore 'uncut ruby' ('oslipad rubin') because it's a gemstone and wouldn't be melted down IRL, but decided to keep it simple. Checked what MC does, and they call it 'malm'/ore too.