### PR TITLE
[fr_ca] Update Canadian French for 0.5.3

### DIFF
--- a/assets/base/lang/fr_ca/base_blocks.json
+++ b/assets/base/lang/fr_ca/base_blocks.json
@@ -90,5 +90,21 @@
     "base:stone_limestone::bricks": "Briques de calcaire",
     "base:ladder_iron": "Échelle en fer",
     "base:workbench": "Établi",
-    "base:pixel_display": "Écran de pixels"
+    "base:pixel_display": "Écran de pixels",
+    "base:grass_blades": "Brins d'herbe",
+    "base:plastic_block::gray": "Plastique gris",
+    "base:plastic_block::white": "Plastique blanc",
+    "base:plastic_block::black": "Plastique noir",
+    "base:plastic_block::red": "Plastique rouge",
+    "base:plastic_block::orange": "Plastique orange",
+    "base:plastic_block::yellow": "Plastique jaune",
+    "base:plastic_block::lime": "Plastique vert citron",
+    "base:plastic_block::green": "Plastique vert",
+    "base:plastic_block::spring_green": "Plastique vert printemps",
+    "base:plastic_block::cyan": "Plastique cyan",
+    "base:plastic_block::azure": "Plastique azur",
+    "base:plastic_block::blue": "Plastique bleu",
+    "base:plastic_block::violet": "Plastique violet",
+    "base:plastic_block::magenta": "Plastique magenta",
+    "base:plastic_block::rose": "Plastique rose"
 }

--- a/assets/base/lang/fr_ca/base_items.json
+++ b/assets/base/lang/fr_ca/base_items.json
@@ -32,5 +32,7 @@
     "base:crowbar": "Pied-de-biche",
     "base:remote_control": "Télécommande",
     "base:revolver": "Révolver",
-    "base:rifle": "Fusil"
+    "base:rifle": "Fusil",
+    "base:naphtha": "Naphta",
+    "base:plastic_pellets": "Balles en plastique"
 }

--- a/assets/base/lang/fr_ca/base_items.json
+++ b/assets/base/lang/fr_ca/base_items.json
@@ -34,5 +34,5 @@
     "base:revolver": "Révolver",
     "base:rifle": "Fusil",
     "base:naphtha": "Naphta",
-    "base:plastic_pellets": "Balles en plastique"
+    "base:plastic_pellets": "Billes en plastique"
 }


### PR DESCRIPTION
I'm torn between using `Balles en plastique` or `Billes en plastique` for `base:plastic_pellets`. If the pellets are not used as ammunition of any sort, or if they are used in a pellet gun, the latter option is more accurate. If they are used as a bullet, the former option *may* be more accurate.

Also, it seems that, in french, naphtha does not have the second "h." Multiple sources write it as `naphta`.